### PR TITLE
fix: add noqa S310 comments to urlopen calls

### DIFF
--- a/src/citations.py
+++ b/src/citations.py
@@ -31,7 +31,7 @@ def get_citations(arxiv_id: str) -> dict:
         raise ValueError(f"Only HTTPS URLs are allowed, got: {url[:50]}")
     try:
         req = Request(url)
-        with urlopen(req, timeout=10) as resp:
+        with urlopen(req, timeout=10) as resp:  # noqa: S310
             data = json.loads(resp.read())
             _last_call = time.time()
             return {

--- a/src/utils.py
+++ b/src/utils.py
@@ -71,7 +71,7 @@ def get_api_response(api_url, max_retries=3, backoff_base=2.0):
     req = Request(api_url)
     for attempt in range(max_retries):
         try:
-            with urlopen(req, timeout=30) as url:
+            with urlopen(req, timeout=30) as url:  # noqa: S310
                 assert url.status == 200, f"arxiv did not return status 200 response: {api_url}"
                 return url.read()
         except (URLError, AssertionError):


### PR DESCRIPTION
CodeFactor flags `urlopen` at src/utils.py:74 and src/citations.py:34. The `_ensure_https()` guard validates before `urlopen` but CodeFactor can't trace across functions.

Closes #54