### PR TITLE
revert: undo lint inference bug from #88

### DIFF
--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   lint:
-    uses: qte77/.github/.github/workflows/lint-md-links.yml@55ea1a9910b7dfe02853437345fd76c009cb858f  # 2026-04-27
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f73ac7241ef37b6103e04d2a8373ff68a4  # 2026-04-27
 ...

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Logs daily stats of papers submitted to [arxiv.org](https://arxiv.org/). Inspire
     OUT_DIR: './data'
     TOPICS: 'cat:cs.CV+OR+cat:cs.LG+OR+cat:cs.CL+OR+cat:cs.AI+OR+cat:cs.NE+OR+cat:cs.RO'
     TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```text
+```
 
 ## Inputs
 


### PR DESCRIPTION
Revert #88 which applied corrupt fence-language fixes due to a state-tracking bug in the inference script. Closing fences were incorrectly treated as openings and got 'bash' appended.