### PR TITLE
chore(claude): add agent scaffolding (rules + statusline)

### DIFF
--- a/.claude/rules/compound-learning.md
+++ b/.claude/rules/compound-learning.md
@@ -1,0 +1,35 @@
+# Compound Learning
+
+Prevent repeated mistakes by systematically promoting learnings.
+
+## Before Solving a Problem
+
+Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
+
+## Promotion Path
+
+1. **1st occurrence** — fix inline, move on
+2. **2nd occurrence** — add to AGENT_LEARNINGS.md (pattern + solution)
+3. **3rd occurrence** — promote to a plugin's `rules/` in `claude-code-plugins`,
+   bump the plugin version, and ship via PR. Consumers receive the rule on next
+   plugin update.
+4. **Recurring workflow** — extract to a plugin's `skills/` (reusable capability)
+
+## When Promoting (step 3)
+
+- Verify the root cause is the same across occurrences
+- Write the rule as a constraint ("do X", "never Y"), not a narrative
+- Reference the AGENT_LEARNINGS.md entry being promoted
+- Remove or link the original entry to avoid duplication
+- **Choose host plugin**: pick the existing plugin whose domain matches the
+  rule; if none fits, create a minimal plugin (see `plugins/planning/` as
+  scaffold)
+- **Bump version**: update `version` in both
+  `plugins/<name>/.claude-plugin/plugin.json` and
+  `.claude-plugin/marketplace.json` — both must match
+- **Sync shared rules**: if the rule belongs in the cross-cutting
+  `.claude/rules/` set, run `make sync` to propagate copies into
+  `workspace-setup` and `workspace-sandbox`, then bump those plugins' versions
+- **Cross-repo workflow**: when the learning surfaces in a consumer repo
+  (qte77/qte77, polyforge, office-forge, etc.), open the promotion PR against
+  `claude-code-plugins`, not against the consumer

--- a/.claude/rules/context-management.md
+++ b/.claude/rules/context-management.md
@@ -1,0 +1,59 @@
+# Context Management (ACE-FCA)
+
+Principles for optimal context window utilization.
+
+## Context Quality Equation
+
+Quality output = Correct context + Complete context + Minimal noise
+
+## Degradation Hierarchy (worst to best)
+
+1. **Incorrect information** - worst, causes cascading errors (garbage in, garbage out)
+2. **Missing information** - leads to assumptions (agent guesses, sometimes wrong)
+3. **Excessive noise** - dilutes signal, wastes capacity (truth buried but still there)
+
+Better to have less correct info than more info with errors.
+
+## Utilization Target
+
+Keep context at **40-60%** capacity. Leave room for:
+
+- Model reasoning
+- Output generation
+- Error recovery
+
+## Context Pollution Sources (What)
+
+These mess up context - compact/summarize immediately:
+
+- File searches (glob/grep results)
+- Code flow traces
+- Edit applications
+- Test/build logs
+- Large JSON blobs from tools
+
+## Workflow Phases
+
+Research → Planning → Implementation. Compact after each phase transition.
+
+## Compaction Triggers (When)
+
+Use `compacting-context` skill when:
+
+- Verbose tool output (logs, JSON, search results)
+- After completing a phase or milestone
+- Before starting new complex task
+
+## Subagent Usage
+
+Use `researching-codebase` skill to:
+
+- Isolate discovery artifacts from main context
+- Return structured findings only
+- Prevent search noise pollution
+
+## Output Guidelines
+
+- Prefer structured summaries over raw dumps
+- Extract only relevant portions from large files
+- Use targeted searches, not broad sweeps

--- a/.claude/rules/core-principles.md
+++ b/.claude/rules/core-principles.md
@@ -1,0 +1,55 @@
+# Core Principles
+
+**MANDATORY for ALL tasks.** These principles override all other guidance when
+conflicts arise. Every decision optimizes for user value, clarity, and usability.
+
+## Code Quality
+
+- **KISS (Keep It Simple, Stupid)** — simplest solution that works.
+- **DRY (Don't Repeat Yourself)** — single source of truth; reference, don't duplicate.
+- **AHA (Avoid Hasty Abstractions)** — three similar lines beats a premature abstraction; extract only when the pattern is stable.
+- **YAGNI (You Aren't Gonna Need It)** — build for the requested behavior, not for imagined future ones.
+
+## Execution
+
+- **Reuse and extend** — use existing patterns and dependencies; extend rather than rebuild.
+- **Consistency and coherence** — validate changes against established conventions; spot inconsistencies before they compound.
+- **Concise and focused** — minimal code/text for the task; touch only task-related code.
+- **Root-cause and first-principles** — solve root problems, not symptoms; understand the "why" before patching.
+
+## Decision
+
+- **Rigor and sufficiency** — research enough to decide with confidence, then move.
+- **High-impact quick wins** — prioritize must-do tasks; ship fast, iterate.
+
+## Communication
+
+- **Clarity** — name things for what they are; state decisions and reasons plainly; prefer concrete examples over abstract framing.
+- **Actionable and concrete** — specific deliverables, measurable outcomes.
+
+## Before Starting Any Task
+
+- [ ] Does this serve user value?
+- [ ] Is this the simplest approach?
+- [ ] Am I duplicating existing work?
+- [ ] Do I actually need this?
+- [ ] Am I touching only relevant code?
+- [ ] What's the root cause I'm solving?
+- [ ] Is this clear to a reader who lacks my context?
+
+## Post-Task Review
+
+Before finishing, ask yourself:
+
+- **Did we forget anything?** — check requirements thoroughly
+- **High-ROI enhancements?** — suggest opportunities (don't implement)
+- **Something to delete?** — remove obsolete/unnecessary code
+
+**IMPORTANT**: Do NOT alter files based on this review. Only output
+suggestions to the user.
+
+## When in Doubt
+
+**STOP. Ask the user.**
+
+Don't assume, don't over-engineer, don't add complexity.

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+#
+# World clock (opt-in)
+# --------------------
+# Local time is always shown. To append additional zones, configure either:
+#
+#   (1) CC_WORLD_CLOCK env var — set in your shell rc; persistent across
+#       sessions. Requires CC restart to change (env is fixed at launch).
+#
+#   (2) ~/.claude/world-clock file — single line of comma-separated zones.
+#       Live toggle: edit/delete the file and the next prompt render picks
+#       it up, no CC restart needed. Use when you want to flip clocks on/off
+#       inside an active session.
+#
+# Precedence: env var wins; file is the fallback. Unset env + missing/empty
+# file = off (default).
+#
+# Zones render in the order you list them. Suggested convention:
+# order east-to-west (sunrise order) so time decreases left-to-right.
+#
+# Each entry is either a bare IANA zone (label defaults to the city, e.g.
+# "Europe/Paris" → "Paris") or "Zone=Label" to override the rendered label
+# (e.g. "America/New_York=NYC" → "NYC"). Mix and match freely.
+#
+# Suggested default (env-var form, copy to your shell rc):
+#   export CC_WORLD_CLOCK="Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles"
+#
+# Short-label variant (terser statusline):
+#   export CC_WORLD_CLOCK="Asia/Tokyo=TYO,Europe/Paris=PAR,Europe/London=LDN,UTC,America/New_York=NYC,America/Los_Angeles=LA"
+#
+# Live-toggle form:
+#   echo "Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles" > ~/.claude/world-clock
+#   rm ~/.claude/world-clock                                                                # turn off
+#
+# Other examples:
+#   export CC_WORLD_CLOCK="Asia/Tokyo,Asia/Singapore,UTC"
+#
+# Use IANA Region/City names (system tzdata under /usr/share/zoneinfo).
+# DST is handled automatically. Invalid zones render as "?<name>" so typos
+# are visible at a glance. On Alpine, install tzdata first: apk add tzdata.
+#
+# When set, world-clock zones render on their own line below the main
+# statusline. If your local zone is in the list it will appear twice —
+# omit it from CC_WORLD_CLOCK to avoid duplication.
+#
+# Curated shortlist (full list: find /usr/share/zoneinfo -type f):
+#   UTC anchor : UTC
+#   Americas   : America/Los_Angeles America/Denver America/Chicago
+#                America/New_York America/Toronto America/Mexico_City
+#                America/Sao_Paulo America/Argentina/Buenos_Aires
+#   Europe     : Europe/London Europe/Dublin Europe/Lisbon Europe/Paris
+#                Europe/Berlin Europe/Madrid Europe/Rome Europe/Amsterdam
+#                Europe/Zurich Europe/Stockholm Europe/Warsaw Europe/Athens
+#                Europe/Istanbul Europe/Moscow
+#   Africa/ME  : Africa/Lagos Africa/Cairo Africa/Johannesburg
+#                Asia/Jerusalem Asia/Dubai Asia/Riyadh
+#   Asia       : Asia/Karachi Asia/Kolkata Asia/Dhaka Asia/Bangkok
+#                Asia/Jakarta Asia/Singapore Asia/Hong_Kong Asia/Shanghai
+#                Asia/Taipei Asia/Seoul Asia/Tokyo
+#   Oceania    : Australia/Perth Australia/Adelaide Australia/Sydney
+#                Pacific/Auckland Pacific/Honolulu
+
+input=$(cat)
+
+# Single jq call extracts all fields (tab-delimited)
+read -r cwd agent model version cost duration lines_added lines_removed \
+    tokens_in tokens_out remaining_pct exc_context <<< "$(echo "$input" | jq -r '[
+    .workspace.current_dir,
+    (.agent.type // "main"),
+    .model.id,
+    (.version // ""),
+    (if .cost.total_cost_usd then (.cost.total_cost_usd * 100 | round / 100 | tostring) + "$" else "" end),
+    (((.cost.total_api_duration_ms // 0) / 1000 / 60 | round | tostring) + "m"),
+    (.cost.total_lines_added // 0 | tostring),
+    (.cost.total_lines_removed // 0 | tostring),
+    (((.context_window.total_input_tokens // 0) / 1000 | floor | tostring) + "k"),
+    (((.context_window.total_output_tokens // 0) / 1000 | floor | tostring) + "k"),
+    (if .context_window.current_usage.input_tokens then
+        (.context_window.context_window_size // 200000) as $win |
+        (.context_window.current_usage.input_tokens // 0) as $in |
+        (.context_window.current_usage.cache_creation_input_tokens // 0) as $cc |
+        (.context_window.current_usage.cache_read_input_tokens // 0) as $cr |
+        (($in + $cc + $cr) / $win * 100) as $used |
+        (100 - $used) | round
+    else
+        .context_window.remaining_percentage // 100
+    end | tostring),
+    (.exceeds_200k_tokens // false | tostring)
+] | join("\t")')"
+
+lines_changed="+${lines_added}/-${lines_removed}"
+tokens="${tokens_in}/${tokens_out}"
+
+# Subtract autocompact buffer to get TRUE usable space
+# Priority: env var > observed default (16.5%)
+if [ -n "$CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" ]; then
+    AUTOCOMPACT_BUFFER_PCT=$(awk "BEGIN {print 100 - $CLAUDE_AUTOCOMPACT_PCT_OVERRIDE}")
+else
+    # Docs claim CLAUDE_AUTOCOMPACT_PCT_OVERRIDE default is 95% (5% buffer),
+    # but /context shows 16.5% buffer and compaction triggers at ~78-85% (issues #18264, #18241).
+    # FIXME: Using observed 16.5% until Claude Code fixes the discrepancy.
+    AUTOCOMPACT_BUFFER_PCT=16.5
+fi
+
+true_free_pct=$(awk "BEGIN {print $remaining_pct - $AUTOCOMPACT_BUFFER_PCT}")
+remaining=$(echo "$true_free_pct" | awk '{printf "%.2f", $1/100}' | sed 's/^0\./\./')
+
+# Color remaining based on TRUE free space threshold (warn when running LOW)
+if [ $(awk "BEGIN {print ($true_free_pct <= 10)}") -eq 1 ]; then
+    ctx_color="\\033[93;41m"  # Bright yellow fg, red bg - CRITICAL (≤10% usable)
+elif [ $(awk "BEGIN {print ($true_free_pct <= 20)}") -eq 1 ]; then
+    ctx_color="\\033[91;48;5;237m"  # Bright red fg, dark gray bg - WARNING (≤20% usable)
+elif [ $(awk "BEGIN {print ($true_free_pct <= 35)}") -eq 1 ]; then
+    ctx_color="\\033[93m"  # Yellow fg - CAUTION (≤35% usable)
+else
+    ctx_color="\\033[0;32m"   # Normal green fg - OK
+fi
+
+user=$(whoami)
+time=$(date +%H:%M:%S)
+
+# Build world-clock line. Source order:
+#   1. $CC_WORLD_CLOCK env var (set in shell rc, requires CC restart to change)
+#   2. ~/.claude/world-clock file content (live toggle — picked up on next render)
+# If your local zone is in the list (e.g. Europe/Paris while in Paris) it will
+# appear twice — omit it to avoid duplication.
+clocks=""
+zones_spec="${CC_WORLD_CLOCK:-$(cat "$HOME/.claude/world-clock" 2>/dev/null)}"
+if [ -n "$zones_spec" ]; then
+    IFS=',' read -ra _zones <<< "$zones_spec"
+    for entry in "${_zones[@]}"; do
+        tz="${entry%%=*}"
+        label="${entry#*=}"
+        [ "$label" = "$entry" ] && label="${tz##*/}"
+        if [ -f "/usr/share/zoneinfo/$tz" ]; then
+            clocks+=" ${label}:$(TZ="$tz" date +%H:%M)"
+        else
+            clocks+=" ?${tz}"
+        fi
+    done
+fi
+
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    branch=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
+    else branch=""
+fi
+
+printf "\\033[0;31magent:%s \\033[0;33mmodel:%s \\033[2mver:%s \\033[0;34mcost:%s \\033[0;36mdur:%s\\n\\033[0;32mlines:%s \\033[2mtokens(i/o):%s ${ctx_color}ctx(free):%s\\033[0m \\033[0;31m>200k:%s\\033[0m\\n\\033[2mdir:%s \\033[0;36mbranch:%s \\033[0;32muser:%s \\033[0;35mtime:%s\\033[0m" "$agent" "$model" "$version" "$cost" "$duration" "$lines_changed" "$tokens" "$remaining" "$exc_context" "$(basename "$cwd")" "$branch" "$user" "$time"
+
+if [ -n "$clocks" ]; then
+    printf "\\n\\033[0;35mclocks:%s\\033[0m" "$clocks"
+fi


### PR DESCRIPTION
## Summary

- Add `.claude/rules/` — three always-loaded behavioral rules (`core-principles`, `context-management`, `compound-learning`) that constrain AI coding agents working in this repo.
- Add `.claude/scripts/statusline.sh` — custom Claude Code statusline rendering agent/model/cost/duration, token usage, autocompact-aware free-context indicator, and an opt-in world-clock line.

## Test plan

- [ ] CI passes (lint + link checks)
- [ ] Lychee finds no broken links in the new markdown
- [ ] Markdown lint passes for the new rule files
- [ ] No changes to runtime code — action behavior unaffected

Generated with Claude <noreply@anthropic.com>