### PR TITLE
fix(security): suppress Bandit B310 for url with runtime scheme guard

### DIFF
--- a/src/citations.py
+++ b/src/citations.py
@@ -31,7 +31,7 @@ def get_citations(arxiv_id: str) -> dict:
         raise ValueError(f"Only HTTPS URLs are allowed, got: {url[:50]}")
     try:
         req = Request(url)
-        with urlopen(req, timeout=10) as resp:  # noqa: S310
+        with urlopen(req, timeout=10) as resp:  # noqa: S310  # nosec B310 - scheme validated above
             data = json.loads(resp.read())
             _last_call = time.time()
             return {


### PR DESCRIPTION
## Summary

Resolves [the CodeFactor B310 finding](https://www.codefactor.io/repository/github/qte77/gha-arxiv-stats-action/issues/main) on `src/citations.py:34`.

## Root cause

CodeFactor runs Bandit, which is a static analyzer. B310 flags any `urllib.request.urlopen` call regardless of context — it can't see that the line above (lines 29-31) explicitly rejects any URL whose lowered form doesn't start with `https://`, and that `API_BASE` is a hardcoded `https://api.semanticscholar.org/...`.

```python
url = f"{API_BASE}/ARXIV:{arxiv_id}?fields={FIELDS}"
if not url.lower().startswith("https://"):
    raise ValueError(f"Only HTTPS URLs are allowed, got: {url[:50]}")
try:
    req = Request(url)
    with urlopen(req, timeout=10) as resp:  # noqa: S310
```

The runtime guard is already defense-in-depth. Bandit's concern (file:/ or custom schemes reaching urlopen) cannot manifest at runtime.

## Fix

Add `# nosec B310 - scheme validated above` alongside the existing `# noqa: S310` comment. Single-line change. No behavior change. No new dependencies.

```python
with urlopen(req, timeout=10) as resp:  # noqa: S310  # nosec B310 - scheme validated above
```

## Why not switch to `requests`?

Bandit's "Further Reading" section recommends the `requests` package as a higher-level HTTP client. Adding `requests` would close the warning at the cost of a new runtime dependency on a package that's currently transitive-free. Given the existing scheme guard, the suppression-with-justification approach is the lower-risk fix.

## Test plan

- [x] `tests/test_citations.py` mocks `src.citations.urlopen` at module level — the line change doesn't affect mocking
- [ ] Post-merge: CodeFactor re-scans and the B310 finding clears

## Checklist
- [x] Tests unchanged (no behavior change)
- [ ] CHANGELOG (defer to maintainer convention for this repo)

Generated with Claude <noreply@anthropic.com>