### PR TITLE
fix(security): restore HTTPS-only validation; PR #100 review fixups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ select = ["E", "F", "I", "W", "S", "C90"]
 max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101"]
+"tests/**" = ["S101"]
 
 [tool.bumpversion]
 current_version = "0.0.1"

--- a/src/citations.py
+++ b/src/citations.py
@@ -1,6 +1,5 @@
 """Semantic Scholar citation enrichment for arxiv paper IDs."""
 
-import json
 import time
 
 import requests
@@ -37,7 +36,7 @@ def get_citations(arxiv_id: str) -> dict:
             "reference_count": data.get("referenceCount", 0),
             "influential_count": data.get("influentialCitationCount", 0),
         }
-    except (requests.RequestException, json.JSONDecodeError):
+    except requests.RequestException:
         _last_call = time.time()
         return {"citation_count": 0, "reference_count": 0, "influential_count": 0}
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -58,6 +58,8 @@ def parse_arxiv_url(url):
 
 
 def get_api_response(api_url, max_retries=3, backoff_base=2.0):
+    if not api_url.lower().startswith("https://"):
+        raise ValueError(f"Only HTTPS URLs are allowed, got: {api_url[:50]}")
     for attempt in range(max_retries):
         try:
             resp = requests.get(api_url, timeout=30)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,6 +37,14 @@ def test_raises_after_max_retries():
             get_api_response("https://export.arxiv.org/api/query?id_list=1234")
 
 
+def test_rejects_non_https():
+    """http:// URL should raise ValueError immediately, never calling requests.get."""
+    with patch("src.utils.requests.get") as mock_get:
+        with pytest.raises(ValueError):
+            get_api_response("http://export.arxiv.org/api/query?id_list=1234")
+    assert mock_get.call_count == 0
+
+
 def test_success_no_retry():
     """Single 200 response — requests.get called exactly once."""
     resp = _make_response(b"success")


### PR DESCRIPTION
## Summary

Addresses three findings from the post-merge review of PR #100:

1. **Restore HTTPS-only validation** in `get_api_response` — PR #100 removed `_ensure_https()` along with the `# noqa: S310` suppression. `requests` rejects `file://` and custom schemes by default but follows `http://` normally, so the explicit https-only invariant added in PR #50 was silently lost. Restored as a 2-line inline guard (no helper — only one call site needs it).
2. **Drop redundant `json.JSONDecodeError` catch** in `get_citations` — `requests.JSONDecodeError` (raised by `resp.json()`) subclasses both `requests.RequestException` AND `json.JSONDecodeError`, so the `RequestException` catch already covers it. Removed the dead entry and the unused `import json`.
3. **Tighten per-file-ignores glob** in `pyproject.toml` — `tests/*` matches only one level deep; `tests/**` future-proofs against nested test directories.

## Why not also restore the check in `get_citations`?

`get_citations` builds its URL from a hardcoded `API_BASE = "https://..."` constant — the check would be untriggerable from the public API. YAGNI applied.

## Test plan

- [x] `uv run pytest -v` — 35 tests pass (one new: `test_rejects_non_https` restored)
- [x] `uv run ruff check src/ tests/` — clean with S+C90
- [x] `uv run ruff check --select S310,B310 src/` — still no findings

Generated with Claude <noreply@anthropic.com>