### PR TITLE
chore: docstring cleanup, parse_arxiv_url hardening, typing fix, v0.0.2 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Types of changes:
 
 ## [Unreleased]
 
+---
+
+## [0.0.2] - 2026-05-13
+
 ### Changed
 
 - HTTP client migrated from `urllib.request` to `requests` in `src/utils.py`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Logs daily stats of papers submitted to [arxiv.org](https://arxiv.org/). Inspired by [stats@arxiv-sanity-lite.com](https://arxiv-sanity-lite.com/stats).
 
-![Version](https://img.shields.io/badge/version-0.0.1-8A2BE2)
+![Version](https://img.shields.io/badge/version-0.0.2-8A2BE2)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Update arxiv.org stats](https://github.com/qte77/gha-arxiv-stats-action/actions/workflows/write-arxiv-stats.yml/badge.svg)](https://github.com/qte77/gha-arxiv-stats-action/actions/workflows/write-arxiv-stats.yml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/gha-arxiv-stats-action/badge)](https://www.codefactor.io/repository/github/qte77/gha-arxiv-stats-action)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gha-arxiv-stats-action"
-version = "0.0.1"
+version = "0.0.2"
 description = "Log daily stats of papers submitted to arxiv.org."
 authors = [
     {name = "qte77", email = "qte@77.gh"}
@@ -30,7 +30,7 @@ max-complexity = 10
 "tests/**" = ["S101"]
 
 [tool.bumpversion]
-current_version = "0.0.1"
+current_version = "0.0.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = false

--- a/src/utils.py
+++ b/src/utils.py
@@ -32,9 +32,9 @@ def parse_arxiv_url(url):
     idv = url[ix + 1 :]  # extract just the id (and the version)
     try:
         rawid, version = idv.split("v")
-    except ValueError as e:
-        raise ValueError(f"malformed arxiv id (expected 'rawidvN'): {idv}") from e
-    return idv, rawid, int(version)
+        return idv, rawid, int(version)
+    except ValueError:
+        raise ValueError(f"malformed arxiv id (expected 'rawidvN'): {idv}") from None
 
 
 def get_api_response(api_url, max_retries=3, backoff_base=2.0):

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,7 +8,7 @@ from os import makedirs
 from os.path import dirname, exists
 
 import requests
-from feedparser import FeedParserDict, parse
+from feedparser import FeedParserDict, parse  # type: ignore[import-untyped]
 
 
 def encode_feedparser_dict(d):

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,27 +1,4 @@
-"""
-TODO short description
-
-arxiv API output
-  'id': 'http://arxiv.org/abs/2406.04221v1',
-  'guidislink': True,
-  'link': 'http://arxiv.org/abs/2406.04221v1',
-  'updated': '2024-06-06T16:20:07Z',
-  'updated_parsed': time.struct_time(
-    tm_year=2024, tm_mon=6, tm_mday=6, tm_hour=16,
-    tm_min=20, tm_sec=7, tm_wday=3, tm_yday=158, tm_isdst=0
-  ),
-  'published': '2024-06-06T16:20:07Z',
-  'published_parsed': time.struct_time(
-    tm_year=2024, tm_mon=6, tm_mday=6, tm_hour=16,
-    tm_min=20, tm_sec=7, tm_wday=3, tm_yday=158, tm_isdst=0
-  ),
-  'title': 'Matching Anything by Segmenting Anything',
-  'title_detail': {
-    'type': 'text/plain', 'language': None,
-    'base': '', 'value': 'Matching Anything by Segmenting Anything'
-    },
-  'summary': 'The robust association of the same'
-"""
+"""Helpers for fetching and parsing arXiv API responses into CSV rows."""
 
 import csv
 import os

--- a/src/utils.py
+++ b/src/utils.py
@@ -30,7 +30,10 @@ def parse_arxiv_url(url):
     if ix < 0:
         raise ValueError(f"bad url: {url}")
     idv = url[ix + 1 :]  # extract just the id (and the version)
-    rawid, version = idv.split("v")
+    try:
+        rawid, version = idv.split("v")
+    except ValueError as e:
+        raise ValueError(f"malformed arxiv id (expected 'rawidvN'): {idv}") from e
     return idv, rawid, int(version)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,11 @@
-"""Tests for get_api_response() retry behavior in src/utils.py."""
+"""Tests for get_api_response() retry behavior and parse_arxiv_url() in src/utils.py."""
 
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 
-from src.utils import get_api_response
+from src.utils import get_api_response, parse_arxiv_url
 
 
 def _make_response(data=b"ok"):
@@ -52,3 +52,23 @@ def test_success_no_retry():
         result = get_api_response("https://export.arxiv.org/api/query?id_list=1234")
     assert result == b"success"
     assert mock_get.call_count == 1
+
+
+def test_parse_arxiv_url_happy_path():
+    """Standard arxiv URL parses into (idv, rawid, version)."""
+    idv, rawid, version = parse_arxiv_url("http://arxiv.org/abs/1512.08756v2")
+    assert idv == "1512.08756v2"
+    assert rawid == "1512.08756"
+    assert version == 2
+
+
+def test_parse_arxiv_url_rejects_missing_v():
+    """ID without version separator raises ValueError naming the malformed input."""
+    with pytest.raises(ValueError, match="malformed arxiv id"):
+        parse_arxiv_url("http://arxiv.org/abs/1512.08756")
+
+
+def test_parse_arxiv_url_rejects_no_slash():
+    """URL without / raises ValueError with 'bad url' message."""
+    with pytest.raises(ValueError, match="bad url"):
+        parse_arxiv_url("not-a-url")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,3 +72,15 @@ def test_parse_arxiv_url_rejects_no_slash():
     """URL without / raises ValueError with 'bad url' message."""
     with pytest.raises(ValueError, match="bad url"):
         parse_arxiv_url("not-a-url")
+
+
+def test_parse_arxiv_url_rejects_non_numeric_version():
+    """Non-numeric version raises ValueError with helpful message, not bare int() error."""
+    with pytest.raises(ValueError, match="malformed arxiv id"):
+        parse_arxiv_url("http://arxiv.org/abs/1512.08756vabc")
+
+
+def test_parse_arxiv_url_rejects_multiple_v():
+    """ID with multiple 'v' separators raises ValueError with helpful message."""
+    with pytest.raises(ValueError, match="malformed arxiv id"):
+        parse_arxiv_url("http://arxiv.org/abs/1512.08756v2v3")


### PR DESCRIPTION
## Summary

Bundles four small follow-ups from the post-PR-#100/#101 cleanup list:

1. **docs**: replace TODO+stale-example module docstring in \`src/utils.py\` with a one-line summary.
2. **fix(utils)**: \`parse_arxiv_url\` now wraps both \`idv.split(\"v\")\` AND \`int(version)\` with a try/except that re-raises \`ValueError\` with a helpful \"malformed arxiv id\" message, replacing the bare \`unpacking\` / \`invalid literal for int()\` errors callers got before. Added 5 TDD pytest cases (happy + 4 malformed-input variants); this function had zero direct test coverage previously.
3. **chore(typing)**: silence Pyright \`Import \"feedparser\" could not be resolved\` warning via \`# type: ignore[import-untyped]\`. \`types-feedparser\` does not exist on PyPI and \`feedparser\` ships no \`py.typed\` marker — per-line ignore is the smallest equivalent fix.
4. **chore(release)**: 0.0.1 → 0.0.2. Rolls the existing \`[Unreleased]\` entries (urllib→requests migration + B310/S310 suppression removal from PR #100) into a dated \`[0.0.2] - 2026-05-13\` section per Keep-a-Changelog. Touches the 3 files configured under \`[tool.bumpversion.files]\`.

## Pre-push review

Two parallel subagents (general + Python-specific) reviewed the staged diff. Caught a real gap in #2: the original wrapper missed \`int(version)\`, so \`...vabc\` IDs bypassed the helpful error. Fixed in commit 5 with 2 additional TDD cases.

## Test plan

- [x] \`uv run pytest -q\` — 40 tests pass (35 baseline + 5 new for \`parse_arxiv_url\`)
- [x] \`uv run ruff check src/ tests/\` — clean with S+C90
- [x] \`uv run ruff format --check src/ tests/\` — clean
- [x] Pyright \`Import \"feedparser\" could not be resolved\` warning gone after commit 3

## Adherence to project principles

- **KISS**: per-line \`# type: ignore\` beats stub-directory rigging
- **YAGNI**: no Makefile, no pyrightconfig.json, no stubs dir
- **DRY/AHA**: no \"split-and-validate\" helper extracted (single call site); test pattern reuses existing \`pytest.raises(..., match=...)\` style
- **Root-cause**: error wrapping at the source, not in the caller \`get_parsed_output\`
- **Touch only task-related code**: each commit scoped to its file/topic

## Notes

- bumpversion config has \`tag = false\` / \`commit = false\` — no auto-tag created. Tag \`v0.0.2\` to be created manually after squash-merge if desired.
- Pre-existing Pyright noise about \`FeedParserDict.__getitem__\` slice typing is unrelated and out of scope (it's a feedparser library typing issue, not import resolution).

Generated with Claude <noreply@anthropic.com>